### PR TITLE
Show a chooser to share

### DIFF
--- a/app/src/main/java/com/androidexperiments/lipflip/utils/AndroidUtils.java
+++ b/app/src/main/java/com/androidexperiments/lipflip/utils/AndroidUtils.java
@@ -114,7 +114,7 @@ public class AndroidUtils
         if(caption != null)
             share.putExtra(Intent.EXTRA_TEXT, caption);
 
-        return share;
+        return Intent.createChooser(share, caption);
     }
 
     /**


### PR DESCRIPTION
Right now if you can choose the "default" app to share. It have more sense that there is not default one. Some times I want to share lipswaps on Facebook and other times on Whatsapp.